### PR TITLE
Add beta netplay support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,10 @@
         version = "3.4.2";
         hash = "sha256-XSVEk3k7Eq55VtkFUD2biLYUt0bUKRh2PKIpWmdx5Uo=";
       };
+      netplay-beta = {
+        version = "4.0.0-mainline-beta.6";
+        hash = "sha256-CicAZ28+yiagG3bjosu02azV6XzP7+JnLhUJ3hdeQbI=";
+      };
       playback = {
         version = "3.4.3";
         hash = "sha256-QsvayemrIztHSVcFh0I1/SOCoO6EsSTItrRQgqTWvG4=";
@@ -59,6 +63,44 @@
 
     packages = genPkgs (pkgs: {
       default = outputs.packages.${pkgs.system}.slippi-launcher;
+      slippi-netplay-beta = pkgs.callPackage ({
+        stdenvNoCC,
+        appimageTools,
+        fetchzip,
+        makeWrapper,
+        lib,
+
+        version ? defaults.netplay-beta.version,
+        hash ? defaults.netplay-beta.hash,
+      }:
+      let
+        pname = "Slippi_Netplay_Mainline-x86_64.AppImage";
+        zip = fetchzip {
+          inherit hash;
+          url = "https://github.com/project-slippi/dolphin/releases/download/v${version}/Mainline-Slippi-${version}-Linux.zip";
+          stripRoot = false;
+        };
+        src = "${zip}/Slippi_Netplay_Mainline-x86_64.AppImage";
+      in
+      stdenvNoCC.mkDerivation {
+        inherit pname version;
+        nativeBuildInputs = [
+          makeWrapper
+        ];
+        src = appimageTools.wrapType2 {
+          inherit pname version src;
+          extraPkgs = pkgs: with pkgs; [ curl libsForQt5.qt5.qttools ];
+        };
+
+        installPhase = ''
+          runHook preInstall
+          mkdir -p "$out/bin"
+          cp -r "$src/bin" "$out"
+          wrapProgram $out/bin/${pname} \
+            --set QT_QPA_PLATFORM xcb
+          runHook postInstall
+        '';
+      }) {};
       slippi-netplay = pkgs.callPackage ({
         stdenvNoCC,
         appimageTools,
@@ -79,7 +121,7 @@
 
           src = appimageTools.wrapType2 {
             inherit pname version src;
-            extraPkgs = pkgs: with pkgs; [curl zlib mpg123];
+            extraPkgs = pkgs: with pkgs; [curl zlib mpg123 ];
 
             postInstall = ''
               ls -la "$out"
@@ -370,6 +412,10 @@
         inherit (lib) mkEnableOption mkOption types mkIf;
         cfg = config.slippi-launcher;
         flakePackages = outputs.packages.${pkgs.system};
+        netplay-beta-package = version: hash:
+          flakePackages.slippi-netplay-beta.overrideAttrs {
+            inherit version hash;
+          };
         netplay-package = version: hash:
           flakePackages.slippi-netplay.overrideAttrs {
             inherit version hash;
@@ -399,6 +445,17 @@
             description = "The hash of the Slippi Netplay AppImage to install.";
           };
 
+          netplayBetaVersion = mkOption {
+            default = defaults.netplay-beta.version;
+            type = types.str;
+            description = "The version of Slippi Netplay (Mainline beta) to install.";
+          };
+          netplayBetaHash = mkOption {
+            default = defaults.netplay-beta.hash;
+            type = types.str;
+            description = "The hash of the Slippi Netplay (Mainline beta) AppImage to install.";
+          };
+
           playbackVersion = mkOption {
             default = defaults.playback.version;
             type = types.str;
@@ -426,6 +483,7 @@
             type = types.str;
             description = "The path to an NTSC Melee ISO.";
           };
+          useNetplayBeta = mkEnableOption "Use the mainline Dolphin instead of the stable version." // { default = false; };
 
           launchMeleeOnPlay = mkEnableOption "Launch Melee in Dolphin when the Play button is pressed." // {default = true;};
 
@@ -453,6 +511,7 @@
         };
         config = let
           cfgNetplayPackage = netplay-package cfg.netplayVersion cfg.netplayHash;
+          cfgNetplayBetaPackage = netplay-beta-package cfg.netplayBetaVersion cfg.netplayBetaHash;
           cfgPlaybackPackage = playback-package cfg.playbackVersion cfg.playbackHash;
           cfgLauncherPackage = launcher-package cfg.launcherVersion cfg.launcherHash;
         in {
@@ -467,6 +526,20 @@
             source = "${pkgs.fetchzip {
               url = "https://github.com/project-slippi/Ishiiruka/releases/download/v${cfg.netplayVersion}/FM-Slippi-${cfg.netplayVersion}-Linux.zip";
               hash = cfg.netplayHash;
+              stripRoot = false;
+            }}/Sys";
+            recursive = false;
+          };
+          home.file.".config/Slippi Launcher/netplay-beta/Slippi_Netplay_Mainline-x86_64.AppImage" = {
+            enable = cfg.useNetplayBeta;
+            source  = "${cfgNetplayBetaPackage}/bin/Slippi_Netplay_Mainline-x86_64.AppImage";
+            recursive = false;
+          };
+          home.file.".config/Slippi Launcher/netplay-beta/Sys" = {
+            enable = cfg.useNetplayBeta;
+            source = "${pkgs.fetchzip {
+              url = "https://github.com/project-slippi/dolphin/releases/download/v${cfg.netplayBetaVersion}/Mainline-Slippi-${cfg.netplayBetaVersion}-Linux.zip";
+              hash = cfg.netplayBetaHash;
               stripRoot = false;
             }}/Sys";
             recursive = false;
@@ -498,13 +571,14 @@
 
                   launchMeleeOnPlay = cfg.launchMeleeOnPlay;
                   enableJukebox = cfg.enableJukebox;
+                  useNetplayBeta = cfg.useNetplayBeta;
 
                   rootSlpPath = cfg.rootSlpPath;
                   useMonthlySubfolders = cfg.useMonthlySubfolders;
                   spectateSlpPath = cfg.spectateSlpPath;
                   extraSlpPaths = cfg.extraSlpPaths;
 
-                  netplayDolphinPath = "${cfgNetplayPackage}/bin/";
+                  netplayDolphinPath = "${if cfg.useNetplayBeta then cfgNetplayBetaPackage else cfgNetplayPackage}/bin/";
                   playbackDolphinPath = "${cfgPlaybackPackage}/bin/";
 
                   autoUpdateLauncher = false;

--- a/flake.nix
+++ b/flake.nix
@@ -69,11 +69,9 @@
         fetchzip,
         makeWrapper,
         lib,
-
         version ? defaults.netplay-beta.version,
         hash ? defaults.netplay-beta.hash,
-      }:
-      let
+      }: let
         pname = "Slippi_Netplay_Mainline-x86_64.AppImage";
         zip = fetchzip {
           inherit hash;
@@ -82,25 +80,25 @@
         };
         src = "${zip}/Slippi_Netplay_Mainline-x86_64.AppImage";
       in
-      stdenvNoCC.mkDerivation {
-        inherit pname version;
-        nativeBuildInputs = [
-          makeWrapper
-        ];
-        src = appimageTools.wrapType2 {
-          inherit pname version src;
-          extraPkgs = pkgs: with pkgs; [ curl libsForQt5.qt5.qttools ];
-        };
+        stdenvNoCC.mkDerivation {
+          inherit pname version;
+          nativeBuildInputs = [
+            makeWrapper
+          ];
+          src = appimageTools.wrapType2 {
+            inherit pname version src;
+            extraPkgs = pkgs: with pkgs; [curl libsForQt5.qt5.qttools];
+          };
 
-        installPhase = ''
-          runHook preInstall
-          mkdir -p "$out/bin"
-          cp -r "$src/bin" "$out"
-          wrapProgram $out/bin/${pname} \
-            --set QT_QPA_PLATFORM xcb
-          runHook postInstall
-        '';
-      }) {};
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out/bin"
+            cp -r "$src/bin" "$out"
+            wrapProgram $out/bin/${pname} \
+              --set QT_QPA_PLATFORM xcb
+            runHook postInstall
+          '';
+        }) {};
       slippi-netplay = pkgs.callPackage ({
         stdenvNoCC,
         appimageTools,
@@ -121,7 +119,7 @@
 
           src = appimageTools.wrapType2 {
             inherit pname version src;
-            extraPkgs = pkgs: with pkgs; [curl zlib mpg123 ];
+            extraPkgs = pkgs: with pkgs; [curl zlib mpg123];
 
             postInstall = ''
               ls -la "$out"
@@ -483,7 +481,7 @@
             type = types.str;
             description = "The path to an NTSC Melee ISO.";
           };
-          useNetplayBeta = mkEnableOption "Use the mainline Dolphin instead of the stable version." // { default = false; };
+          useNetplayBeta = mkEnableOption "Use the mainline Dolphin instead of the stable version." // {default = false;};
 
           launchMeleeOnPlay = mkEnableOption "Launch Melee in Dolphin when the Play button is pressed." // {default = true;};
 
@@ -532,7 +530,7 @@
           };
           home.file.".config/Slippi Launcher/netplay-beta/Slippi_Netplay_Mainline-x86_64.AppImage" = {
             enable = cfg.useNetplayBeta;
-            source  = "${cfgNetplayBetaPackage}/bin/Slippi_Netplay_Mainline-x86_64.AppImage";
+            source = "${cfgNetplayBetaPackage}/bin/Slippi_Netplay_Mainline-x86_64.AppImage";
             recursive = false;
           };
           home.file.".config/Slippi Launcher/netplay-beta/Sys" = {
@@ -578,7 +576,11 @@
                   spectateSlpPath = cfg.spectateSlpPath;
                   extraSlpPaths = cfg.extraSlpPaths;
 
-                  netplayDolphinPath = "${if cfg.useNetplayBeta then cfgNetplayBetaPackage else cfgNetplayPackage}/bin/";
+                  netplayDolphinPath = "${
+                    if cfg.useNetplayBeta
+                    then cfgNetplayBetaPackage
+                    else cfgNetplayPackage
+                  }/bin/";
                   playbackDolphinPath = "${cfgPlaybackPackage}/bin/";
 
                   autoUpdateLauncher = false;

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,8 @@ along with the hash like so:
   home-manager.users.YOUR_USERNAME = {
     slippi-launcher.netplayVersion = "3.4.0";
     slippi-launcher.netplayHash = "sha256-d1iawMsMwFElUqFmwWAD9rNsDdQr2LKscU8xuJPvxYg=";
+    slippi-launcher.netplayBetaVersion = "4.0.0-mainline-beta.6";
+    slippi-launcher.netplayBetaHash = "sha256-CicAZ28+yiagG3bjosu02azV6XzP7+JnLhUJ3hdeQbI=";
     slippi-launcher.playbackVersion = "3.4.0";
     slippi-launcher.playbackHash = "sha256-d1iawMsMwFElUqFmwWAD9rNsDdQr2LKscU8xuJPvxYg=";
   };
@@ -98,6 +100,17 @@ along with the hash like so:
 
 So when a Slippi update is released, you can usually bump the version to match
 and update the hash with whatever `nix` says it is.
+
+# Beta
+You can enable the beta netplay client by adding this to the configuration:
+```nix
+{
+  home-manager.users.YOUR_USERNAME = {
+    slippi-launcher.useBetaNetplay = true;
+  };
+}
+```
+The beta netplay client is *not* downloaded unless it is enabled. When enabled it is set as the default as well.
 
 # Cache
 


### PR DESCRIPTION
This adds support for the new mainline dolphin. Enable by using `useBetaNetplay = true` in the config.
I know there's a draft PR for Vulkan support. Somehow, the mainline dolphin supports Vulkan OOB.