### PR TITLE
chore: slippi-netplay-beta 4.0.0-mainline-beta.6 -> (...).7

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,8 +30,8 @@
         hash = "sha256-sQ8JkmhKxr34kVHHGCAoQf0IwO36CgQPi4MSrnvb384=";
       };
       netplay-beta = {
-        version = "4.0.0-mainline-beta.6";
-        hash = "sha256-CicAZ28+yiagG3bjosu02azV6XzP7+JnLhUJ3hdeQbI=";
+        version = "4.0.0-mainline-beta.7";
+        hash = "sha256-Et6OKSU/+9YZ49rIr0evXNlPfGolg1PSxmuuAZnV4jc=";
       };
       playback = {
         version = "3.4.4";


### PR DESCRIPTION
Updated the beta version up to beta 7.