### PR TITLE
Refactor the whole project

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,15 +22,14 @@
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        ]
       },
       "locked": {
-        "lastModified": 1721042469,
-        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
+        "lastModified": 1742649964,
+        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
+        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
         "type": "github"
       },
       "original": {
@@ -67,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722321190,
-        "narHash": "sha256-WeVWVRqkgrbLzmk6FfJoloJ7Xe7HWD27Pv950IUG2kI=",
+        "lastModified": 1744735751,
+        "narHash": "sha256-OPpfgL3qUIbQdbmp1/ZwnlsuTLooHN4or0EABnZTFRY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4fcd54df7cbb1d79cbe81209909ee8514d6b17a4",
+        "rev": "db7738e67a101ad945abbcb447e1310147afaf1b",
         "type": "github"
       },
       "original": {
@@ -82,32 +81,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716769173,
-        "narHash": "sha256-7EXDb5WBw+d004Agt+JHC/Oyh/KTUglOaQ4MNjBbo5w=",
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9ca3f649614213b2aaf5f1e16ec06952fe4c2632",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -24,26 +24,6 @@
     self,
     ...
   }: let
-    defaults = {
-      netplay = {
-        version = "3.4.5";
-        hash = "sha256-XspvaRlLNAeJ2KyagS4PWOqaJHVZqvw/a3Z3mAxOFJI=";
-      };
-      netplay-beta = {
-        version = "4.0.0-mainline-beta.9";
-        hash = "sha256-gG7/E4fkAo7P/i2or5J8sQrriqSQducOytN+oP0+BfA=";
-      };
-      playback = {
-        version = "3.4.5";
-        hash = "sha256-iCBdlcBPSRT8m772sqI+gSfNmVNAug0SfkSwVUE6+fE=";
-      };
-      launcher = {
-        version = "2.11.8";
-        hash = "sha256-8krtzo878nh6oMTUhyPJIa/RkkebqQckb4Mh2+9SaiU=";
-      };
-    };
-
-    inherit (self) outputs;
     forSystems = nixpkgs.lib.genAttrs [
       # "aarch64-darwin"
       # "x86_64-darwin"
@@ -54,186 +34,35 @@
     genPkgs = func: (forSystems (system: func (pkgsFor system)));
   in {
     overlays = {
-      default = outputs.overlays.slippi;
+      default = self.overlays.slippi;
 
       slippi = final: prev: {
-        inherit (outputs.packages.${final.system}.slippi) slippi-netplay slippi-playback slippi-launcher;
+        inherit (self.packages.${final.system}.slippi) slippi-netplay slippi-playback slippi-launcher;
       };
     };
 
     packages = genPkgs (pkgs: {
-      default = outputs.packages.${pkgs.system}.slippi-launcher;
-      slippi-netplay-beta = pkgs.callPackage ({
-        stdenvNoCC,
-        appimageTools,
-        fetchzip,
-        makeWrapper,
-        lib,
-        version ? defaults.netplay-beta.version,
-        hash ? defaults.netplay-beta.hash,
-      }: let
-        pname = "Slippi_Netplay_Mainline-x86_64.AppImage";
-        zip = fetchzip {
-          inherit hash;
-          url = "https://github.com/project-slippi/dolphin/releases/download/v${version}/Mainline-Slippi-${version}-Linux.zip";
-          stripRoot = false;
-        };
-        src = "${zip}/Slippi_Netplay_Mainline-x86_64.AppImage";
-      in
-        stdenvNoCC.mkDerivation {
-          inherit pname version;
-          nativeBuildInputs = [
-            makeWrapper
-          ];
-          src = appimageTools.wrapType2 {
-            inherit pname version src;
-            extraPkgs = pkgs: with pkgs; [curl libsForQt5.qt5.qttools];
-          };
-
-          installPhase = ''
-            runHook preInstall
-            mkdir -p "$out/bin"
-            cp -r "$src/bin" "$out"
-            wrapProgram $out/bin/${pname} \
-              --set QT_QPA_PLATFORM xcb
-            runHook postInstall
-          '';
-        }) {};
-      slippi-netplay = pkgs.callPackage ({
-        stdenvNoCC,
-        appimageTools,
-        fetchzip,
-        version ? defaults.netplay.version,
-        hash ? defaults.netplay.hash,
-      }: let
-        pname = "Slippi_Online-x86_64.AppImage";
-        zip = fetchzip {
-          inherit hash;
-          url = "https://github.com/project-slippi/Ishiiruka/releases/download/v${version}/FM-Slippi-${version}-Linux.zip";
-          stripRoot = false;
-        };
-        src = "${zip}/Slippi_Online-x86_64.AppImage";
-      in
-        stdenvNoCC.mkDerivation {
-          inherit pname version;
-
-          src = appimageTools.wrapType2 {
-            inherit pname version src;
-            extraPkgs = pkgs: with pkgs; [curl zlib mpg123];
-
-            postInstall = ''
-              ls -la "$out"
-              wrapProgram $out/bin/${pname}-${version} \
-                --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
-            '';
-          };
-
-          installPhase = ''
-            runHook preInstall
-
-            mkdir -p "$out/bin"
-            cp -r "$src/bin" "$out"
-
-            runHook postInstall
-          '';
-        }) {};
-      slippi-playback = pkgs.callPackage ({
-        stdenvNoCC,
-        appimageTools,
-        fetchzip,
-        version ? defaults.playback.version,
-        hash ? defaults.playback.hash,
-      }: let
-        pname = "Slippi_Playback-x86_64.AppImage";
-        zip = fetchzip {
-          inherit hash;
-          url = "https://github.com/project-slippi/Ishiiruka-Playback/releases/download/v${version}/playback-${version}-Linux.zip";
-          stripRoot = false;
-        };
-        src = "${zip}/Slippi_Playback-x86_64.AppImage";
-      in
-        stdenvNoCC.mkDerivation {
-          inherit pname version;
-
-          src = appimageTools.wrapType2 {
-            inherit pname version src;
-            extraPkgs = pkgs: with pkgs; [curl zlib mpg123];
-
-            postInstall = ''
-              ls -la "$out"
-              wrapProgram $out/bin/${pname}-${version} \
-                --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
-            '';
-          };
-
-          installPhase = ''
-            runHook preInstall
-
-            mkdir -p "$out/bin"
-            cp -r "$src/bin" "$out"
-
-            runHook postInstall
-          '';
-        }) {};
-      slippi-launcher = pkgs.callPackage ({
-        stdenvNoCC,
-        appimageTools,
-        fetchurl,
-        copyDesktopItems,
-        version ? defaults.launcher.version,
-        hash ? defaults.launcher.hash,
-      }: let
-        pname = "slippi-launcher-appimage";
-
-        src = fetchurl {
-          inherit hash;
-          url = "https://github.com/project-slippi/slippi-launcher/releases/download/v${version}/Slippi-Launcher-${version}-x86_64.AppImage";
-        };
-
-        appImageContents = appimageTools.extractType2 {
-          inherit pname version src;
-        };
-      in
-        stdenvNoCC.mkDerivation {
-          inherit pname version;
-
-          src = appimageTools.wrapType2 {
-            inherit pname version src;
-            extraPkgs = pkgs: with pkgs; [curl zlib mpg123];
-
-            postInstall = ''
-              ls -la "$out"
-              wrapProgram $out/bin/${pname}-${version} \
-                --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
-            '';
-          };
-
-          # TODO: see if we can convince upstream to let us specify command line
-          # arguments to denote where the netplay and playback binaries are?
-          # this might eliminate the need for the home manager module
-          installPhase = ''
-            runHook preInstall
-
-            mkdir -p "$out/bin"
-            mkdir -p "$out/share/applications"
-            cp -r "$src/bin" "$out"
-            cp -r "${appImageContents}/$(readlink "${appImageContents}/slippi-launcher.png")" "$out/share/applications/"
-            sed '/Icon/d' "${appImageContents}/slippi-launcher.desktop" > "$out/share/applications/slippi-launcher.desktop"
-            sed '/Exec/d' "${appImageContents}/slippi-launcher.desktop" > "$out/share/applications/slippi-launcher.desktop"
-            echo "Icon=$out/share/applications/slippi-launcher.png" >> "$out/share/applications/slippi-launcher.desktop"
-            echo "Exec=$out/bin/${pname} %U" >> "$out/share/applications/slippi-launcher.desktop"
-
-            runHook postInstall
-          '';
-
-          nativeBuildInputs = [copyDesktopItems];
-        }) {};
+      default = self.packages.${pkgs.system}.slippi-launcher;
+      slippi-netplay-beta = pkgs.callPackage ./pkgs/slippi-netplay-beta.nix {};
+      slippi-netplay = pkgs.callPackage ./pkgs/slippi-netplay.nix {};
+      slippi-playback = pkgs.callPackage ./pkgs/slippi-playback.nix {};
+      slippi-launcher = pkgs.callPackage ./pkgs/slippi-launcher.nix {};
     });
 
     formatter = genPkgs (p: p.alejandra);
 
+    nixosModules = {
+      default = self.nixosModules.gamecube-controller-adapter;
+      gamecube-controller-adapter = ./modules/nixos-gc-controller-adapter.nix;
+    };
+
+    homeManagerModules = {
+      default = self.homeManagerModules.slippi-launcher;
+      slippi-launcher = ./modules/hm.nix;
+    };
+
     checks = genPkgs (pkgs: {
-      inherit (outputs.packages.${pkgs.system}) slippi-launcher slippi-netplay slippi-playback slippi-netplay-beta;
+      inherit (self.packages.${pkgs.system}) slippi-launcher slippi-netplay slippi-playback slippi-netplay-beta;
       git-hooks = git-hooks.lib.${pkgs.system}.run {
         src = ./.;
         hooks = {
@@ -254,51 +83,8 @@
           with pkgs.lib; {
             imports = [
               home-manager.nixosModules.home-manager
-              (
-                # nixos/tests/common/auto.nix from nixpkgs
-                {config, ...}: let
-                  cfg = config.test-support.displayManager.auto;
-                in {
-                  options = {
-                    test-support.displayManager.auto = {
-                      enable = mkOption {
-                        default = false;
-                        description = ''
-                          Whether to enable the fake "auto" display manager, which
-                          automatically logs in the user specified in the
-                          {option}`user` option.  This is mostly useful for
-                          automated tests.
-                        '';
-                      };
-                      user = mkOption {
-                        default = "root";
-                        description = "The user account to login automatically.";
-                      };
-                    };
-                  };
-                  config = {
-                    services.xserver.displayManager.lightdm.enable = cfg.enable;
-                    services.displayManager.autoLogin = {
-                      enable = cfg.enable;
-                      user = cfg.user;
-                    };
-                    security.pam.services.lightdm-autologin.text = mkIf cfg.enable (mkForce ''
-                      auth     requisite pam_nologin.so
-                      auth     required  pam_succeed_if.so quiet
-                      auth     required  pam_permit.so
-                      account  include   lightdm
-                      password include   lightdm
-                      session  include   lightdm
-                    '');
-                  };
-                }
-              )
-              {
-                services.xserver.enable = true;
-                test-support.displayManager.auto.enable = true;
-                services.displayManager.defaultSession = mkDefault "none+icewm";
-                services.xserver.windowManager.icewm.enable = true;
-              }
+              "${nixpkgs}/nixos/tests/common/auto.nix"
+              "${nixpkgs}/nixos/tests/common/x11.nix"
             ];
             users.users.daniel = {
               isNormalUser = true;
@@ -308,20 +94,22 @@
             };
             test-support.displayManager.auto.user = "daniel";
             home-manager.users.daniel = {
-              imports = with outputs.homeManagerModules; [
+              imports = with self.homeManagerModules; [
                 slippi-launcher
               ];
               slippi-launcher.enable = true;
               home = {
                 username = "daniel";
                 homeDirectory = "/home/daniel";
-                stateVersion = "24.11";
+                stateVersion = "25.05";
               };
             };
             environment.systemPackages = with pkgs; [jq];
-            system.stateVersion = "24.11";
+            system.stateVersion = "25.05";
           };
-        testScript = {nodes, ...}: ''
+        testScript = {nodes, ...}: let
+          hashes = import ./hashes.nix;
+        in ''
           def as_user(cmd: str):
               """
               Return a shell command for running a shell command as a specific user.
@@ -330,8 +118,8 @@
 
           with subtest("ensure slippi launcher settings file references correct versions"):
               machine.wait_for_unit("default.target")
-              machine.succeed("grep ${defaults.netplay.version} '/home/daniel/.config/Slippi Launcher/Settings'")
-              machine.succeed("grep ${defaults.playback.version} '/home/daniel/.config/Slippi Launcher/Settings'")
+              machine.succeed("grep ${hashes.netplay.version} '/home/daniel/.config/Slippi Launcher/Settings'")
+              machine.succeed("grep ${hashes.playback.version} '/home/daniel/.config/Slippi Launcher/Settings'")
 
           with subtest("ensure netplay appimage version is correct"):
               machine.wait_for_unit("default.target")
@@ -339,256 +127,10 @@
               machine.wait_for_file("/home/daniel/.Xauthority")
               machine.succeed("xauth merge /home/daniel/.Xauthority")
               machine.succeed(as_user("""
-              "''$(jq -r '.settings.netplayDolphinPath' '/home/daniel/.config/Slippi Launcher/Settings')/Slippi_Online-x86_64.AppImage" --version | grep ${defaults.netplay.version}
+              "''$(jq -r '.settings.netplayDolphinPath' '/home/daniel/.config/Slippi Launcher/Settings')/Slippi_Online-x86_64.AppImage" --version | grep ${hashes.netplay.version}
               """))
         '';
       };
     });
-
-    nixosModules = {
-      default = {
-        imports = with outputs.nixosModules; [
-          gamecube-controller-adapter
-        ];
-      };
-
-      gamecube-controller-adapter = {
-        lib,
-        config,
-        ...
-      }: let
-        inherit (lib) mkEnableOption mkOption types mkIf;
-        cfg = config.gamecube-controller-adapter;
-      in {
-        # defaults here are true since we assume if you're importing the module, you
-        # want it on ;)
-        options.gamecube-controller-adapter = {
-          enable = mkEnableOption "Enable the optimal gamecube controller adapter experience." // {default = true;};
-
-          overclocking-kernel-module.enable = mkEnableOption "Turn on gamecube controller adapter overclocking kernel module." // {default = true;};
-
-          udev-rules.enable = mkEnableOption "Turn on udev rules for your gamecube controller adapter." // {default = true;};
-          udev-rules.rules = mkOption {
-            default = ''
-              ATTRS{idVendor}=="057e", ATTRS{idProduct}=="0337", MODE="666", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device" TAG+="uaccess"
-            '';
-            type = types.lines;
-            description = "To be appended to services.udev.extraRules if gcc.rules.enable is set.";
-          };
-        };
-
-        config = {
-          gamecube-controller-adapter.udev-rules.enable = mkIf cfg.enable true;
-          gamecube-controller-adapter.overclocking-kernel-module.enable = mkIf cfg.enable true;
-
-          services.udev.extraRules = mkIf cfg.udev-rules.enable cfg.udev-rules.rules;
-
-          boot.extraModulePackages = mkIf cfg.overclocking-kernel-module.enable [
-            # https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/gcadapter-oc-kmod/default.nix
-            config.boot.kernelPackages.gcadapter-oc-kmod
-          ];
-          boot.kernelModules = mkIf cfg.overclocking-kernel-module.enable [
-            "gcadapter_oc"
-          ];
-        };
-      };
-    };
-
-    homeManagerModules = {
-      default = {
-        imports = with outputs.homeManagerModules; [
-          slippi-launcher
-        ];
-      };
-
-      slippi-launcher = {
-        lib,
-        pkgs,
-        config,
-        ...
-      }: let
-        inherit (lib) mkEnableOption mkOption types mkIf;
-        cfg = config.slippi-launcher;
-        flakePackages = outputs.packages.${pkgs.system};
-        netplay-beta-package = version: hash:
-          flakePackages.slippi-netplay-beta.overrideAttrs {
-            inherit version hash;
-          };
-        netplay-package = version: hash:
-          flakePackages.slippi-netplay.overrideAttrs {
-            inherit version hash;
-          };
-        playback-package = version: hash:
-          flakePackages.slippi-playback.overrideAttrs {
-            inherit version hash;
-          };
-        launcher-package = version: hash:
-          flakePackages.slippi-launcher.overrideAttrs {
-            inherit version hash;
-          };
-      in {
-        # defaults here are true since we assume if you're importing the module, you
-        # want it on ;)
-        options.slippi-launcher = {
-          enable = mkEnableOption "Install Slippi Launcher" // {default = true;};
-
-          netplayVersion = mkOption {
-            default = defaults.netplay.version;
-            type = types.str;
-            description = "The version of Slippi Netplay to install.";
-          };
-          netplayHash = mkOption {
-            default = defaults.netplay.hash;
-            type = types.str;
-            description = "The hash of the Slippi Netplay AppImage to install.";
-          };
-
-          netplayBetaVersion = mkOption {
-            default = defaults.netplay-beta.version;
-            type = types.str;
-            description = "The version of Slippi Netplay (Mainline beta) to install.";
-          };
-          netplayBetaHash = mkOption {
-            default = defaults.netplay-beta.hash;
-            type = types.str;
-            description = "The hash of the Slippi Netplay (Mainline beta) AppImage to install.";
-          };
-
-          playbackVersion = mkOption {
-            default = defaults.playback.version;
-            type = types.str;
-            description = "The version of Slippi Playback to install.";
-          };
-          playbackHash = mkOption {
-            default = defaults.playback.hash;
-            type = types.str;
-            description = "The hash of the Slippi Playback AppImage to install.";
-          };
-
-          launcherVersion = mkOption {
-            default = defaults.launcher.version;
-            type = types.str;
-            description = "The version of Slippi Launcher to install.";
-          };
-          launcherHash = mkOption {
-            default = defaults.launcher.hash;
-            type = types.str;
-            description = "The hash of the Slippi Launcher AppImage to install.";
-          };
-
-          isoPath = mkOption {
-            default = "";
-            type = types.str;
-            description = "The path to an NTSC Melee ISO.";
-          };
-          useNetplayBeta = mkEnableOption "Use the mainline Dolphin instead of the stable version." // {default = false;};
-
-          launchMeleeOnPlay = mkEnableOption "Launch Melee in Dolphin when the Play button is pressed." // {default = true;};
-
-          enableJukebox = mkEnableOption "Enable in-game music via Slippi Jukebox. Incompatible with WASAPI." // {default = true;};
-
-          rootSlpPath = mkOption {
-            default = "${config.home.homeDirectory}/Slippi";
-            type = types.str;
-            description = "The folder where your SLP replays should be saved.";
-          };
-
-          useMonthlySubfolders = mkEnableOption "Save replays to monthly subfolders";
-
-          spectateSlpPath = mkOption {
-            default = "${cfg.rootSlpPath}/Spectate";
-            type = types.nullOr types.str;
-            description = "The folder where spectated games should be saved.";
-          };
-
-          extraSlpPaths = mkOption {
-            default = [];
-            type = types.listOf types.str;
-            description = "Choose any additional SLP directories that should show up in the replay browser.";
-          };
-        };
-        config = let
-          cfgNetplayPackage = netplay-package cfg.netplayVersion cfg.netplayHash;
-          cfgNetplayBetaPackage = netplay-beta-package cfg.netplayBetaVersion cfg.netplayBetaHash;
-          cfgPlaybackPackage = playback-package cfg.playbackVersion cfg.playbackHash;
-          cfgLauncherPackage = launcher-package cfg.launcherVersion cfg.launcherHash;
-        in {
-          home.packages = [(mkIf cfg.enable cfgLauncherPackage)];
-          home.file.".config/Slippi Launcher/netplay/Slippi_Online-x86_64.AppImage" = {
-            enable = cfg.enable;
-            source = "${cfgNetplayPackage}/bin/Slippi_Online-x86_64.AppImage";
-            recursive = false;
-          };
-          home.file.".config/Slippi Launcher/netplay/Sys" = {
-            enable = cfg.enable;
-            source = "${pkgs.fetchzip {
-              url = "https://github.com/project-slippi/Ishiiruka/releases/download/v${cfg.netplayVersion}/FM-Slippi-${cfg.netplayVersion}-Linux.zip";
-              hash = cfg.netplayHash;
-              stripRoot = false;
-            }}/Sys";
-            recursive = false;
-          };
-          home.file.".config/Slippi Launcher/netplay-beta/Slippi_Netplay_Mainline-x86_64.AppImage" = {
-            enable = cfg.useNetplayBeta;
-            source = "${cfgNetplayBetaPackage}/bin/Slippi_Netplay_Mainline-x86_64.AppImage";
-            recursive = false;
-          };
-          home.file.".config/Slippi Launcher/netplay-beta/Sys" = {
-            enable = cfg.useNetplayBeta;
-            source = "${pkgs.fetchzip {
-              url = "https://github.com/project-slippi/dolphin/releases/download/v${cfg.netplayBetaVersion}/Mainline-Slippi-${cfg.netplayBetaVersion}-Linux.zip";
-              hash = cfg.netplayBetaHash;
-              stripRoot = false;
-            }}/Sys";
-            recursive = false;
-          };
-          home.file.".config/Slippi Launcher/playback/Slippi_Playback-x86_64.AppImage" = {
-            enable = cfg.enable;
-            source = "${cfgPlaybackPackage}/bin/Slippi_Playback-x86_64.AppImage";
-            recursive = false;
-          };
-          home.file.".config/Slippi Launcher/playback/Sys" = {
-            enable = cfg.enable;
-            source = "${
-              pkgs.fetchzip {
-                url = "https://github.com/project-slippi/Ishiiruka-Playback/releases/download/v${cfg.playbackVersion}/playback-${cfg.playbackVersion}-Linux.zip";
-                hash = cfg.netplayHash;
-                stripRoot = false;
-              }
-            }/Sys";
-            recursive = false;
-          };
-          xdg.configFile."Slippi Launcher/Settings" = {
-            enable = cfg.enable;
-            source = let
-              jsonFormat = pkgs.formats.json {};
-            in
-              jsonFormat.generate "slippi-config" {
-                settings = {
-                  isoPath = cfg.isoPath;
-
-                  launchMeleeOnPlay = cfg.launchMeleeOnPlay;
-                  enableJukebox = cfg.enableJukebox;
-                  useNetplayBeta = cfg.useNetplayBeta;
-
-                  rootSlpPath = cfg.rootSlpPath;
-                  useMonthlySubfolders = cfg.useMonthlySubfolders;
-                  spectateSlpPath = cfg.spectateSlpPath;
-                  extraSlpPaths = cfg.extraSlpPaths;
-
-                  netplayDolphinPath = "${
-                    if cfg.useNetplayBeta
-                    then cfgNetplayBetaPackage
-                    else cfgNetplayPackage
-                  }/bin/";
-                  playbackDolphinPath = "${cfgPlaybackPackage}/bin/";
-
-                  autoUpdateLauncher = false;
-                };
-              };
-          };
-        };
-      };
-    };
   };
 }

--- a/hashes.nix
+++ b/hashes.nix
@@ -1,0 +1,18 @@
+{
+  netplay = {
+    version = "3.4.5";
+    hash = "sha256-XspvaRlLNAeJ2KyagS4PWOqaJHVZqvw/a3Z3mAxOFJI=";
+  };
+  netplay-beta = {
+    version = "4.0.0-mainline-beta.9";
+    hash = "sha256-gG7/E4fkAo7P/i2or5J8sQrriqSQducOytN+oP0+BfA=";
+  };
+  playback = {
+    version = "3.4.5";
+    hash = "sha256-iCBdlcBPSRT8m772sqI+gSfNmVNAug0SfkSwVUE6+fE=";
+  };
+  launcher = {
+    version = "2.11.9";
+    hash = "sha256-ocKM8m1OCJTaWUJC9Gat5V2mIyzamNxkFt+3LW6FZ3k=";
+  };
+}

--- a/modules/hm.nix
+++ b/modules/hm.nix
@@ -1,0 +1,165 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}: let
+  hashes = import ../hashes.nix;
+  inherit (lib) mkEnableOption mkOption types mkIf;
+  cfg = config.slippi-launcher;
+  netplay-beta-package = version: hash:
+    pkgs.callPackage ../pkgs/slippi-netplay-beta.nix {
+      inherit version hash;
+    };
+  netplay-package = version: hash:
+    pkgs.callPackage ../pkgs/slippi-netplay.nix {
+      inherit version hash;
+    };
+  playback-package = version: hash:
+    pkgs.callPackage ../pkgs/slippi-playback.nix {
+      inherit version hash;
+    };
+  launcher-package = version: hash:
+    pkgs.callPackage ../pkgs/slippi-launcher.nix {
+      inherit version hash;
+    };
+in {
+  options.slippi-launcher = {
+    enable = mkEnableOption "Install Slippi Launcher" // {default = true;};
+
+    netplayVersion = mkOption {
+      default = hashes.netplay.version;
+      type = types.str;
+      description = "The version of Slippi Netplay to install.";
+    };
+    netplayHash = mkOption {
+      default = hashes.netplay.hash;
+      type = types.str;
+      description = "The hash of the Slippi Netplay AppImage to install.";
+    };
+
+    netplayBetaVersion = mkOption {
+      default = hashes.netplay-beta.version;
+      type = types.str;
+      description = "The version of Slippi Netplay (Mainline beta) to install.";
+    };
+    netplayBetaHash = mkOption {
+      default = hashes.netplay-beta.hash;
+      type = types.str;
+      description = "The hash of the Slippi Netplay (Mainline beta) AppImage to install.";
+    };
+
+    playbackVersion = mkOption {
+      default = hashes.playback.version;
+      type = types.str;
+      description = "The version of Slippi Playback to install.";
+    };
+    playbackHash = mkOption {
+      default = hashes.playback.hash;
+      type = types.str;
+      description = "The hash of the Slippi Playback AppImage to install.";
+    };
+
+    launcherVersion = mkOption {
+      default = hashes.launcher.version;
+      type = types.str;
+      description = "The version of Slippi Launcher to install.";
+    };
+    launcherHash = mkOption {
+      default = hashes.launcher.hash;
+      type = types.str;
+      description = "The hash of the Slippi Launcher AppImage to install.";
+    };
+
+    isoPath = mkOption {
+      default = "";
+      type = types.str;
+      description = "The path to an NTSC Melee ISO.";
+    };
+    useNetplayBeta = mkEnableOption "Use the mainline Dolphin instead of the stable version." // {default = false;};
+
+    launchMeleeOnPlay = mkEnableOption "Launch Melee in Dolphin when the Play button is pressed." // {default = true;};
+
+    enableJukebox = mkEnableOption "Enable in-game music via Slippi Jukebox. Incompatible with WASAPI." // {default = true;};
+
+    rootSlpPath = mkOption {
+      default = "${config.home.homeDirectory}/Slippi";
+      type = types.str;
+      description = "The folder where your SLP replays should be saved.";
+    };
+
+    useMonthlySubfolders = mkEnableOption "Save replays to monthly subfolders";
+
+    spectateSlpPath = mkOption {
+      default = "${cfg.rootSlpPath}/Spectate";
+      type = types.nullOr types.str;
+      description = "The folder where spectated games should be saved.";
+    };
+
+    extraSlpPaths = mkOption {
+      default = [];
+      type = types.listOf types.str;
+      description = "Choose any additional SLP directories that should show up in the replay browser.";
+    };
+  };
+  config = mkIf cfg.enable (let
+    cfgNetplayPackage = netplay-package cfg.netplayVersion cfg.netplayHash;
+    cfgNetplayBetaPackage = netplay-beta-package cfg.netplayBetaVersion cfg.netplayBetaHash;
+    cfgPlaybackPackage = playback-package cfg.playbackVersion cfg.playbackHash;
+    cfgLauncherPackage = launcher-package cfg.launcherVersion cfg.launcherHash;
+  in {
+    home.packages = [cfgLauncherPackage];
+    home.file.".config/Slippi Launcher/netplay/Slippi_Online-x86_64.AppImage" = {
+      source = "${lib.getExe cfgNetplayPackage}";
+      recursive = false;
+    };
+    home.file.".config/Slippi Launcher/netplay/Sys" = {
+      source = "${cfgNetplayPackage.raw-zip}/Sys";
+      recursive = false;
+    };
+    home.file.".config/Slippi Launcher/netplay-beta/Slippi_Netplay_Mainline-x86_64.AppImage" = {
+      source = "${lib.getExe cfgNetplayBetaPackage}";
+      recursive = false;
+    };
+    home.file.".config/Slippi Launcher/netplay-beta/Sys" = {
+      source = "${cfgNetplayBetaPackage.raw-zip}/Sys";
+      recursive = false;
+    };
+    home.file.".config/Slippi Launcher/playback/Slippi_Playback-x86_64.AppImage" = {
+      source = "${lib.getExe cfgPlaybackPackage}";
+      recursive = false;
+    };
+    home.file.".config/Slippi Launcher/playback/Sys" = {
+      source = "${cfgPlaybackPackage.raw-zip}/Sys";
+      recursive = false;
+    };
+    xdg.configFile."Slippi Launcher/Settings" = {
+      source = let
+        jsonFormat = pkgs.formats.json {};
+      in
+        jsonFormat.generate "slippi-config" {
+          settings = {
+            isoPath = cfg.isoPath;
+
+            launchMeleeOnPlay = cfg.launchMeleeOnPlay;
+            enableJukebox = cfg.enableJukebox;
+            useNetplayBeta = cfg.useNetplayBeta;
+
+            rootSlpPath = cfg.rootSlpPath;
+            useMonthlySubfolders = cfg.useMonthlySubfolders;
+            spectateSlpPath = cfg.spectateSlpPath;
+            extraSlpPaths = cfg.extraSlpPaths;
+
+            netplayDolphinPath = "${
+              if cfg.useNetplayBeta
+              then cfgNetplayBetaPackage
+              else cfgNetplayPackage
+            }/bin/";
+            playbackDolphinPath = "${cfgPlaybackPackage}/bin/";
+
+            autoUpdateLauncher = false;
+          };
+        };
+    };
+  });
+}

--- a/modules/nixos-gc-controller-adapter.nix
+++ b/modules/nixos-gc-controller-adapter.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  inherit (lib) mkEnableOption mkOption types mkIf;
+  cfg = config.gamecube-controller-adapter;
+in {
+  # defaults here are true since we assume if you're importing the module, you
+  # want it on ;)
+  options.gamecube-controller-adapter = {
+    enable = mkEnableOption "Enable the optimal gamecube controller adapter experience." // {default = true;};
+
+    overclocking-kernel-module.enable = mkEnableOption "Turn on gamecube controller adapter overclocking kernel module." // {default = true;};
+
+    udev-rules.enable = mkEnableOption "Turn on udev rules for your gamecube controller adapter." // {default = true;};
+    udev-rules.rules = mkOption {
+      default = ''
+        ATTRS{idVendor}=="057e", ATTRS{idProduct}=="0337", MODE="666", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device" TAG+="uaccess"
+      '';
+      type = types.lines;
+      description = "To be appended to services.udev.extraRules if gcc.rules.enable is set.";
+    };
+  };
+
+  config = {
+    gamecube-controller-adapter.udev-rules.enable = mkIf cfg.enable true;
+    gamecube-controller-adapter.overclocking-kernel-module.enable = mkIf cfg.enable true;
+
+    services.udev.extraRules = mkIf cfg.udev-rules.enable cfg.udev-rules.rules;
+
+    boot.extraModulePackages = mkIf cfg.overclocking-kernel-module.enable [
+      # https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/gcadapter-oc-kmod/default.nix
+      config.boot.kernelPackages.gcadapter-oc-kmod
+    ];
+    boot.kernelModules = mkIf cfg.overclocking-kernel-module.enable [
+      "gcadapter_oc"
+    ];
+  };
+}

--- a/pkgs/slippi-launcher.nix
+++ b/pkgs/slippi-launcher.nix
@@ -1,0 +1,38 @@
+let
+  hashes = import ../hashes.nix;
+in
+  {
+    appimageTools,
+    fetchurl,
+    makeWrapper,
+    version ? hashes.launcher.version,
+    hash ? hashes.launcher.hash,
+  }:
+    appimageTools.wrapType2 rec {
+      pname = "slippi-launcher";
+      inherit version;
+      nativeBuildInputs = [
+        makeWrapper
+      ];
+      src = fetchurl {
+        inherit hash;
+        url = "https://github.com/project-slippi/slippi-launcher/releases/download/v${version}/Slippi-Launcher-${version}-x86_64.AppImage";
+      };
+
+      appImageContents = appimageTools.extract {
+        inherit pname src version;
+      };
+      extraInstallCommands = ''
+        wrapProgram "$out/bin/${pname}" \
+          --inherit-argv0 \
+          --set QT_QPA_PLATFORM xcb
+        mkdir -p "$out/share/applications"
+        cp -r "${appImageContents}/$(readlink "${appImageContents}/slippi-launcher.png")" "$out/share/applications/"
+
+        sed -e '/Icon/d' -e '/Exec/d' "${appImageContents}/slippi-launcher.desktop" > "$out/share/applications/slippi-launcher.desktop"
+        echo "Icon=$out/share/applications/slippi-launcher.png" >> "$out/share/applications/slippi-launcher.desktop"
+        echo "Exec=$out/bin/${pname} %U" >> "$out/share/applications/slippi-launcher.desktop"
+      '';
+
+      extraPkgs = pkgs: with pkgs; [curl zlib mpg123];
+    }

--- a/pkgs/slippi-netplay-beta.nix
+++ b/pkgs/slippi-netplay-beta.nix
@@ -1,0 +1,32 @@
+let
+  hashes = import ../hashes.nix;
+in
+  {
+    appimageTools,
+    fetchzip,
+    makeWrapper,
+    version ? hashes.netplay-beta.version,
+    hash ? hashes.netplay-beta.hash,
+  }:
+    appimageTools.wrapType2 rec {
+      pname = "Slippi_Netplay_Mainline-x86_64.AppImage";
+      inherit version;
+      nativeBuildInputs = [
+        makeWrapper
+      ];
+      rawZip = fetchzip {
+        inherit hash;
+        url = "https://github.com/project-slippi/dolphin/releases/download/v${version}/Mainline-Slippi-${version}-Linux.zip";
+        stripRoot = false;
+      };
+      src = "${rawZip}/Slippi_Netplay_Mainline-x86_64.AppImage";
+      extraInstallCommands = ''
+        wrapProgram "$out/bin/${pname}" \
+          --inherit-argv0 \
+          --set QT_QPA_PLATFORM xcb
+      '';
+
+      extraPkgs = pkgs: with pkgs; [curl zlib mpg123];
+
+      passthru.raw-zip = rawZip;
+    }

--- a/pkgs/slippi-netplay.nix
+++ b/pkgs/slippi-netplay.nix
@@ -1,0 +1,34 @@
+let
+  hashes = import ../hashes.nix;
+in
+  {
+    appimageTools,
+    fetchzip,
+    makeWrapper,
+    version ? hashes.netplay.version,
+    hash ? hashes.netplay.hash,
+  }:
+    appimageTools.wrapType2 rec {
+      pname = "Slippi_Online-x86_64.AppImage";
+      inherit version;
+      nativeBuildInputs = [
+        makeWrapper
+      ];
+
+      rawZip = fetchzip {
+        inherit hash;
+        url = "https://github.com/project-slippi/Ishiiruka/releases/download/v${version}/FM-Slippi-${version}-Linux.zip";
+        stripRoot = false;
+      };
+      src = "${rawZip}/Slippi_Online-x86_64.AppImage";
+
+      extraInstallCommands = ''
+        wrapProgram "$out/bin/${pname}" \
+          --inherit-argv0 \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+      '';
+
+      extraPkgs = pkgs: with pkgs; [curl zlib mpg123];
+
+      passthru.raw-zip = rawZip;
+    }

--- a/pkgs/slippi-playback.nix
+++ b/pkgs/slippi-playback.nix
@@ -1,0 +1,34 @@
+let
+  hashes = import ../hashes.nix;
+in
+  {
+    stdenvNoCC,
+    appimageTools,
+    fetchzip,
+    makeWrapper,
+    version ? hashes.playback.version,
+    hash ? hashes.playback.hash,
+  }:
+    appimageTools.wrapType2 rec {
+      pname = "Slippi_Playback-x86_64.AppImage";
+      inherit version;
+      nativeBuildInputs = [
+        makeWrapper
+      ];
+      rawZip = fetchzip {
+        inherit hash;
+        url = "https://github.com/project-slippi/Ishiiruka-Playback/releases/download/v${version}/playback-${version}-Linux.zip";
+        stripRoot = false;
+      };
+      src = "${rawZip}/Slippi_Playback-x86_64.AppImage";
+
+      extraInstallCommands = ''
+        wrapProgram "$out/bin/${pname}" \
+          --inherit-argv0 \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+      '';
+
+      extraPkgs = pkgs: with pkgs; [curl zlib mpg123];
+
+      passthru.raw-zip = rawZip;
+    }


### PR DESCRIPTION
Refactor the project
- Move each package to their own file
- Change the packages' downloading method to expose the zip file it
  downloads (for use by the home manager module)
- Move all the hashes for the packages to its own file.
- Move the modules to their own files
- Clean up the flake.nix itself
- BONUS: update slippi-launcher to v2.11.9

This means that *if* this is merged, you can close #20 safely.