### PR TITLE
Fix beta netplay option in the readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,8 +32,9 @@ will also need to specify where your Melee ISO is. Here is an example:
 
 ```nix
 {
-  inputs.slippi.url = "github:lytedev/slippi-nix";
   inputs.nixpkgs.url = "...";
+  inputs.slippi.url = "github:lytedev/slippi-nix";
+  inputs.slippi.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = {slippi, nixpkgs, ...}: {
     nixosConfigurations = nixpkgs.lib.nixosSystem {


### PR DESCRIPTION
Fix the readme.md changing the useBetaNetplay for useNetplayBeta and add slippi nixpkgs follows nixpkgs to avoid versioning mismatch with the appimage's vulkan/opengl and the system's.