### PR TITLE
fix: make launcher settings file mutable for login credentials

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,19 @@ You can enable the beta netplay client by adding this to the configuration:
 ```
 The beta netplay client is *not* downloaded unless it is enabled. When enabled it is set as the default as well.
 
+# Settings and Login
+
+The Home Manager module creates a mutable settings file at
+`~/.config/Slippi Launcher/Settings`. Nix-managed settings (ISO path,
+Dolphin paths, etc.) are merged into this file on each Home Manager
+activation, but the launcher is free to write to it as well — so login
+credentials and any other launcher-managed settings are preserved across
+rebuilds.
+
+If you are upgrading from an older version of this module that used a
+read-only symlink, the stale symlink will be cleaned up automatically on
+the next activation.
+
 # Cache
 
 You may also want to leverage our Cachix binary cache. There isn't _much_


### PR DESCRIPTION
Replace xdg.configFile with a home.activation script so the Slippi Launcher Settings file is a regular mutable file instead of a read-only symlink to the Nix store. This allows the launcher to write to it (e.g. for saving login credentials).

On each home-manager activation, Nix-managed settings are merged into the existing file using jq, preserving any extra keys the launcher has written (like auth tokens). Stale symlinks from the previous module version are cleaned up automatically.

Fixes: https://github.com/lytedev/slippi-nix/issues/32