### PR TITLE
feat: standalone launcher that works without home-manager module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,11 +45,20 @@
       };
 
       packages = genPkgs (pkgs: {
-        default = self.packages.${pkgs.system}.slippi-launcher;
+        default = self.packages.${pkgs.system}.slippi-launcher-desktop;
         slippi-netplay-beta = pkgs.callPackage ./packages/slippi-netplay-beta.nix { };
         slippi-netplay = pkgs.callPackage ./packages/slippi-netplay.nix { };
         slippi-playback = pkgs.callPackage ./packages/slippi-playback.nix { };
         slippi-launcher = pkgs.callPackage ./packages/slippi-launcher.nix { };
+        slippi-launcher-desktop = pkgs.callPackage ./packages/slippi-launcher-desktop.nix {
+          inherit (pkgs) formats;
+          inherit (self.packages.${pkgs.system})
+            slippi-launcher
+            slippi-netplay
+            slippi-netplay-beta
+            slippi-playback
+            ;
+        };
       });
 
       formatter = genPkgs (p: p.nixfmt-rfc-style);
@@ -67,6 +76,7 @@
       checks = genPkgs (pkgs: {
         inherit (self.packages.${pkgs.system})
           slippi-launcher
+          slippi-launcher-desktop
           slippi-netplay
           slippi-playback
           slippi-netplay-beta

--- a/packages/slippi-launcher-desktop.nix
+++ b/packages/slippi-launcher-desktop.nix
@@ -1,0 +1,61 @@
+# A wrapped slippi-launcher that works standalone (without the Home Manager
+# module) by seeding the config directory with correct Dolphin paths and
+# AppImage symlinks on each launch.
+{
+  lib,
+  writeShellApplication,
+  jq,
+  slippi-launcher,
+  slippi-netplay,
+  slippi-netplay-beta,
+  slippi-playback,
+  formats,
+}:
+let
+  managedSettings = (formats.json { }).generate "slippi-managed-settings" {
+    settings = {
+      netplayDolphinPath = "${slippi-netplay}/bin/";
+      playbackDolphinPath = "${slippi-playback}/bin/";
+      autoUpdateLauncher = false;
+    };
+  };
+in
+writeShellApplication {
+  name = "slippi-launcher";
+  runtimeInputs = [ jq ];
+  text = ''
+    slippi_dir="''${XDG_CONFIG_HOME:-$HOME/.config}/Slippi Launcher"
+    settings="$slippi_dir/Settings"
+
+    mkdir -p "$slippi_dir/netplay" "$slippi_dir/netplay-beta" "$slippi_dir/playback"
+
+    # Symlink Nix-wrapped AppImages and Sys directories so the launcher
+    # can detect versions and Dolphin can find its system files.
+    ln -sfn ${lib.getExe slippi-netplay} "$slippi_dir/netplay/Slippi_Online-x86_64.AppImage"
+    ln -sfn ${slippi-netplay.raw-zip}/Sys "$slippi_dir/netplay/Sys"
+    ln -sfn ${lib.getExe slippi-netplay-beta} "$slippi_dir/netplay-beta/Slippi_Netplay_Mainline-x86_64.AppImage"
+    ln -sfn ${slippi-netplay-beta.raw-zip}/Sys "$slippi_dir/netplay-beta/Sys"
+    ln -sfn ${lib.getExe slippi-playback} "$slippi_dir/playback/Slippi_Playback-x86_64.AppImage"
+    ln -sfn ${slippi-playback.raw-zip}/Sys "$slippi_dir/playback/Sys"
+
+    # Remove stale symlink from older module versions
+    if [ -L "$settings" ]; then
+      rm "$settings"
+    fi
+
+    if [ -f "$settings" ]; then
+      # Merge Nix-managed settings on top of existing (Nix paths win)
+      jq -s '.[0] * .[1]' "$settings" ${managedSettings} > "$settings.tmp"
+      mv "$settings.tmp" "$settings"
+    else
+      cp ${managedSettings} "$settings"
+      chmod u+w "$settings"
+    fi
+
+    exec ${lib.getExe slippi-launcher} "$@"
+  '';
+
+  meta = slippi-launcher.meta // {
+    description = "Slippi Launcher (standalone, pre-configured for NixOS)";
+  };
+}


### PR DESCRIPTION
Add slippi-launcher-desktop package — a wrapper around the base launcher that automatically sets up Dolphin paths, AppImage symlinks, and a mutable Settings file on each launch. This allows the launcher to work standalone without requiring the Home Manager module.

The default flake output now points to slippi-launcher-desktop, so 'nix run github:lytedev/slippi-nix' works out of the box. The base slippi-launcher package is still available for the HM module.

Updated readme with standalone usage examples, Home Manager section heading, and a packages reference table. Removed the To Do section since standalone usage is now supported.

Closes: https://github.com/lytedev/slippi-nix/issues/23