### PR TITLE
Add mime type for slippi files

### DIFF
--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -156,6 +156,23 @@ in
         source = "${cfgPlaybackPackage.raw-zip}/Sys";
         recursive = false;
       };
+
+      xdg = {
+        mimeApps.defaultApplications = {
+          "application/x-slippi" = "slippi-launcher.desktop";
+        };
+        dataFile."mime/packages/x-slippi.xml".text = ''
+          <?xml version="1.0" encoding="UTF-8"?>
+          <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+            <mime-type type="application/x-slippi">
+              <comment>Slippi Replay</comment>
+              <glob pattern="*.slp"/>
+              <icon name="slippi-launcher"/>
+            </mime-type>
+          </mime-info>
+        '';
+      };
+
       # Use an activation script instead of xdg.configFile so the settings
       # file is mutable. The launcher needs to write to it (e.g. login
       # credentials). Nix-managed settings are merged on each activation,

--- a/packages/slippi-launcher.nix
+++ b/packages/slippi-launcher.nix
@@ -40,9 +40,10 @@ in
       --set QT_QPA_PLATFORM xcb
     mkdir -p "$out/share/applications"
     cp -r "${appImageContents}/$(readlink "${appImageContents}/slippi-launcher.png")" "$out/share/applications/"
+    install -Dm644 "${appImageContents}/slippi-launcher.png" $out/share/icons/hicolor/512x512/apps/${pname}.png
 
     sed -e '/Icon/d' -e '/Exec/d' "${appImageContents}/slippi-launcher.desktop" > "$out/share/applications/slippi-launcher.desktop"
-    echo "Icon=$out/share/applications/slippi-launcher.png" >> "$out/share/applications/slippi-launcher.desktop"
+    echo "Icon=slippi-launcher" >> "$out/share/applications/slippi-launcher.desktop"
     echo "Exec=$out/bin/${pname} %U" >> "$out/share/applications/slippi-launcher.desktop"
   '';
 }


### PR DESCRIPTION
Creating a mime type for slippi files (and setting the slippi launcher as the default application for them) makes opening `.slp` files from your web browser/file browser/xdg-open on the command line/etc. open them with the launcher which in turn starts the playback dolphin with them.

I also took the liberty of moving the icon file to the proper place which makes `.slp` files use the slippi icon out of the box.