### PR TITLE
fix: remove ozone flags from dolphin packages that broke version dete

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -142,18 +142,21 @@
                   """
                   return f"sudo -u daniel -i -- bash -c \"{cmd}\""
 
-              with subtest("ensure slippi launcher settings file references correct versions"):
+              with subtest("ensure slippi launcher settings file exists"):
                   machine.wait_for_unit("default.target")
-                  machine.succeed("grep ${hashes.netplay.version} '/home/daniel/.config/Slippi Launcher/Settings'")
-                  machine.succeed("grep ${hashes.playback.version} '/home/daniel/.config/Slippi Launcher/Settings'")
+                  machine.succeed("test -f '/home/daniel/.config/Slippi Launcher/Settings'")
+                  machine.succeed("jq -e '.settings.autoUpdateLauncher == false' '/home/daniel/.config/Slippi Launcher/Settings'")
 
-              with subtest("ensure netplay appimage version is correct"):
+              with subtest("ensure dolphin appimages report correct versions"):
                   machine.wait_for_unit("default.target")
                   machine.wait_for_x()
                   machine.wait_for_file("/home/daniel/.Xauthority")
                   machine.succeed("xauth merge /home/daniel/.Xauthority")
                   machine.succeed(as_user("""
-                  "''$(jq -r '.settings.netplayDolphinPath' '/home/daniel/.config/Slippi Launcher/Settings')/Slippi_Online-x86_64.AppImage" --version | grep ${hashes.netplay.version}
+                  '/home/daniel/.config/Slippi Launcher/netplay/Slippi_Online-x86_64.AppImage' --version 2>&1 | grep ${hashes.netplay.version}
+                  """))
+                  machine.succeed(as_user("""
+                  '/home/daniel/.config/Slippi Launcher/playback/Slippi_Playback-x86_64.AppImage' --version 2>&1 | grep ${hashes.playback.version}
                   """))
             '';
         };

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -193,11 +193,9 @@ in
               spectateSlpPath = cfg.spectateSlpPath;
               extraSlpPaths = cfg.extraSlpPaths;
 
-              netplayDolphinPath = "${
-                if cfg.useNetplayBeta then cfgNetplayBetaPackage else cfgNetplayPackage
-              }/bin/";
-              playbackDolphinPath = "${cfgPlaybackPackage}/bin/";
-
+              # The launcher ignores netplayDolphinPath/playbackDolphinPath; it
+              # always looks for AppImages under ~/.config/Slippi Launcher/{netplay,playback}/.
+              # The home.file symlinks above are what actually prevent downloads.
               autoUpdateLauncher = false;
             };
           };

--- a/packages/slippi-launcher-desktop.nix
+++ b/packages/slippi-launcher-desktop.nix
@@ -12,10 +12,11 @@
   formats,
 }:
 let
+  # The launcher ignores netplayDolphinPath/playbackDolphinPath; it always
+  # looks for AppImages under ~/.config/Slippi Launcher/{netplay,playback}/.
+  # The symlinks below are what actually prevent downloads.
   managedSettings = (formats.json { }).generate "slippi-managed-settings" {
     settings = {
-      netplayDolphinPath = "${slippi-netplay}/bin/";
-      playbackDolphinPath = "${slippi-playback}/bin/";
       autoUpdateLauncher = false;
     };
   };

--- a/packages/slippi-netplay.nix
+++ b/packages/slippi-netplay.nix
@@ -38,7 +38,6 @@ in
     ;
   extraInstallCommands = ''
     wrapProgram "$out/bin/${pname}" \
-      --inherit-argv0 \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+      --inherit-argv0
   '';
 }

--- a/packages/slippi-playback.nix
+++ b/packages/slippi-playback.nix
@@ -36,7 +36,6 @@ in
     ;
   extraInstallCommands = ''
     wrapProgram "$out/bin/${pname}" \
-      --inherit-argv0 \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+      --inherit-argv0
   '';
 }


### PR DESCRIPTION
# Summary

  - Remove `--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations` flags from slippi-netplay and slippi-playback wrappers
  - Remove dead netplayDolphinPath/playbackDolphinPath settings from both the standalone wrapper and home-manager module
  - Update integration tests to verify AppImage --version output directly

# Problem

  The Slippi launcher checks installed Dolphin versions by running dolphin --version and parsing stdout. Our Nix
  wrapProgram was prepending --ozone-platform-hint=auto (a Chromium/Electron flag) to every invocation. Dolphin
  (Ishiiruka) is a wxWidgets app — it doesn't understand this flag, so it errors out immediately:

```
Unknown long option 'ozone-platform-hint'
```

  The launcher gets no version string back → interprets this as "no version installed" → marks the installation as
  "outdated" → downloads fresh binaries from GitHub on every launch, completely defeating the Nix packaging.

  Note that slippi-netplay-beta (the mainline Dolphin fork) was unaffected — it already correctly uses `--set
  QT_QPA_PLATFORM xcb` instead of the ozone flags.

# Additional cleanup

  The netplayDolphinPath and playbackDolphinPath settings we were injecting into the launcher's Settings file are
  completely ignored by the v2.13.3 launcher. The launcher hardcodes its search paths to ~/.config/Slippi
  Launcher/{netplay,playback}/ and never reads those settings. The symlinks placed by the wrapper script and
  home-manager module into those directories are what actually prevent downloads.