### PR TITLE
chore: update launcher to 2.14.2

### DIFF
--- a/hashes.nix
+++ b/hashes.nix
@@ -12,7 +12,7 @@
     hash = "sha256-LWo5gIXQck4dq9uKOYWElPsIUw2/GcMboteQsAx549k=";
   };
   launcher = {
-    version = "2.13.3";
-    hash = "sha256-5tFl0ezk/yMkfd59kUKxGZBvt5MqnoCvxRSepy7O8BQ=";
+    version = "2.14.2";
+    hash = "sha256-bF2QY4xGDBv/6w482x1LGr7uvbu665XOWPndv+U7W74=";
   };
 }


### PR DESCRIPTION
Updates launcher to 2.14.2 in `hashes.nix`.

- Updated version value.
- Removed previous hash value, ran `nix build .` on fork, copied output SHA hash.
- Added output SHA hash to hashes.nix.
- Confirmed build with `nix build`.